### PR TITLE
Correcting a suspected bug in FirebaseListFactory handling of child_added

### DIFF
--- a/src/database/firebase_list_factory.ts
+++ b/src/database/firebase_list_factory.ts
@@ -134,7 +134,7 @@ function firebaseListObservable(ref: firebase.database.Reference | firebase.data
           // If the initial load has not been set and the current key is
           // the last key of the initialArray, we know we have hit the
           // initial load
-          if (!isInitiallyEmpty) {
+          if (!isInitiallyEmpty && !hasInitialLoad) {
             if (child.key === lastKey) {
               hasInitialLoad = true;
               obs.next(preserveSnapshot ? initialArray : initialArray.map(utils.unwrapMapFn));


### PR DESCRIPTION
Create a `FirebaseListObservable` on a non-empty reference ordered by key, then remove the last child in the list. The `FirebaseListObservable` emits the correct list with the last item removed.
Then add the same item (i.e. using the same key) back to the list. Because `hasInitialLoad` is not checked in the `child_added` event handler, and because `child.key === lastKey`, the function returns prematurely and `onChildAdded` is not called. As a result the `FirebaseListObservable` emits an unchanged list, without appending the item as expected.

Sorry I haven't been able to create a unit test to demonstrate the bug. I hope the description is clear enough! Thanks